### PR TITLE
Windows: Pause from menu shouldn't affect Break.

### DIFF
--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -608,7 +608,6 @@ namespace MainWindow {
 
 		case ID_EMULATION_PAUSE:
 			NativeMessageReceived("pause", "");
-			Core_EnableStepping(false);
 			break;
 
 		case ID_EMULATION_STOP:


### PR DESCRIPTION
They're separate states, and pausing can be done now without break.